### PR TITLE
Babel 6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ By default, configuration lives in `sails.config.babel`.  The configuration key 
 Parameter      | Type                | Details
 -------------- | ------------------- |:---------------------------------
 compile        | ((boolean)) | Whether or not sails should compile future JS code.  Defaults to `true`.
-stage   | ((integer)) | Which [stage](http://babeljs.io/docs/usage/experimental/) of Proposals to use 0 being the most experimental.  Defaults to 2.
-loose          | ((boolean)) | Whether or not use babel's [loose](http://babeljs.io/docs/usage/loose/) mode.  Defaults to `true`.
-ignore          | ((boolean/Regex)) | Can be `false` or a regex of what to ignore. For default mode see http://babeljs.io/docs/usage/require/
-only          | ((Regex)) | Whether or not use babel's [loose](http://babeljs.io/docs/usage/loose/) mode. For default mode see http://babeljs.io/docs/usage/require/
-extensions          | ((array)) | Pass an array of extensions, such as ['.js', '.es'].  For default mode see http://babeljs.io/docs/usage/require/
+presets        | ((array)) | Which [presets](http://babeljs.io/docs/plugins/#presets) to transpile your code with. Defaults to [es2015](http://babeljs.io/docs/plugins/preset-es2015/).
+ignore         | ((boolean/Regex)) | Can be `false` or a regex of what to ignore. For default mode see http://babeljs.io/docs/usage/require/
+only           | ((Regex)) | Whether or not use babel's [loose](http://babeljs.io/docs/usage/loose/) mode. For default mode see http://babeljs.io/docs/usage/require/
+extensions     | ((array)) | Pass an array of extensions, such as ['.js', '.es'].  For default mode see http://babeljs.io/docs/usage/require/
 
 That&rsquo;s it!

--- a/index.js
+++ b/index.js
@@ -15,11 +15,8 @@ module.exports = function(sails) {
       __configKey__: {
         // Turn babel compile on by default
         compile: true,
-        //Activates experimental functionality such as ES7 async/await
-        stage: 2,
-        //See http://babeljs.io/docs/usage/loose
-        //Can be "all", false or a an array, e.g. ["es6.classes", "es6.properties.computed"]
-        loose: "all",
+        // Activates preset tranformations
+        presets: ['es2015'],
         //can be false or a regex. Defaults to node_modules in babel
         ignore: null,
         //can be any regex. Only these files will be transpiled
@@ -40,13 +37,12 @@ module.exports = function(sails) {
         sails.log.verbose("Babel hook deactivated.");
       } else {
 
-        //Load babel and override the default require; with experimental features,
-        //such as async/await.
+        // Load babel
+        var options = {};
 
-        var options = {
-          loose: sails.config[this.configKey].loose,
-          stage: sails.config[this.configKey].stage
-        };
+        if (sails.config[this.configKey].presets && sails.config[this.configKey].presets.length > 0) {
+          options.presets = sails.config[this.configKey].presets;
+        }
 
         if (sails.config[this.configKey].ignore !== null) {
           options.ignore = sails.config[this.configKey].ignore;
@@ -60,8 +56,7 @@ module.exports = function(sails) {
           options.extensions = sails.config[this.configKey].extensions;
         }
 
-        require("babel/register")(options);
-
+        require("babel-core/register")(options);
 
         sails.log.verbose("Babel hook activated. Enjoy ES6/7 power in your Sails app.");
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "isHook": true
   },
   "dependencies": {
-    "babel": "^5.0.9"
+    "babel-core": "^6.1.2",
+    "babel-preset-es2015": "^6.1.2"
   },
   "devDependencies": {
     "glob": "^5.0.3",


### PR DESCRIPTION
* Updated to Babel 6 with default support for the [es2015](http://babeljs.io/docs/plugins/preset-es2015) preset
* Removed ```loose``` and ```stage``` options from config and docs (no longer relevant)
* Added ```presets``` to config and docs